### PR TITLE
Implement inline suggestion handlers for Telegram filters

### DIFF
--- a/tg_register.py
+++ b/tg_register.py
@@ -28,6 +28,28 @@ bot = Bot(token=BOT_TOKEN)
 app = FastAPI()
 DB_PATH = "tg_users.db"
 
+# Значения по умолчанию для подсказок фильтров
+SCHEDULE_SUGGESTIONS = [
+    "полный день",
+    "гибкий график",
+    "сменный график",
+]
+
+WORK_FORMAT_SUGGESTIONS = [
+    "дистанционно",
+    "офис",
+    "гибрид",
+]
+
+EMPLOYMENT_TYPE_SUGGESTIONS = [
+    "полная",
+    "частичная",
+    "проектная",
+    "стажировка",
+]
+
+SALARY_SUGGESTIONS = ["50000", "100000", "150000"]
+
 @app.on_event("startup")
 async def on_startup():
     webhook_url = os.getenv("WEBHOOK_URL")
@@ -81,11 +103,75 @@ async def telegram_webhook(request: Request, token: str):
             await bot.send_message(user_id, "Введите ключевое слово для поиска вакансий:")
         # Выбор региона из подсказок
         elif data.startswith("region_suggest_"):
-            area_id = data.split("_")[-1]
+            area_id = int(data.split("_")[-1])
             await save_user_setting(user_id, "region", area_id)
             await set_pending(user_id, None)
+
+            await call.answer()
             await call.message.edit_reply_markup()
-            await bot.send_message(user_id, "Регион сохранён 👍")
+
+            await bot.send_message(user_id, "✅ Регион установлен!")
+            await bot.send_message(
+                user_id,
+                "Ваши настройки:",
+                reply_markup=build_settings_keyboard(),
+            )
+        elif data.startswith("schedule_suggest_"):
+            value = data.split("_")[-1]
+            await save_user_setting(user_id, "schedule", value)
+            await set_pending(user_id, None)
+
+            await call.answer()
+            await call.message.edit_reply_markup()
+
+            await bot.send_message(user_id, "✅ График работы установлен!")
+            await bot.send_message(
+                user_id,
+                "Ваши настройки:",
+                reply_markup=build_settings_keyboard(),
+            )
+        elif data.startswith("work_format_suggest_"):
+            value = data.split("_")[-1]
+            await save_user_setting(user_id, "work_format", value)
+            await set_pending(user_id, None)
+
+            await call.answer()
+            await call.message.edit_reply_markup()
+
+            await bot.send_message(user_id, "✅ Формат работы установлен!")
+            await bot.send_message(
+                user_id,
+                "Ваши настройки:",
+                reply_markup=build_settings_keyboard(),
+            )
+        elif data.startswith("salary_suggest_"):
+            value = data.split("_")[-1]
+            await save_user_setting(user_id, "salary", value)
+            await set_pending(user_id, None)
+
+            await call.answer()
+            await call.message.edit_reply_markup()
+
+            await bot.send_message(user_id, "✅ Зарплата установлена!")
+            await bot.send_message(
+                user_id,
+                "Ваши настройки:",
+                reply_markup=build_settings_keyboard(),
+            )
+        elif data.startswith("employment_type_suggest_"):
+            value = data.split("_")[-1]
+            await save_user_setting(user_id, "employment_type", value)
+            await set_pending(user_id, None)
+
+            await call.answer()
+            await call.message.edit_reply_markup()
+
+            await bot.send_message(user_id, "✅ Тип занятости установлен!")
+            await bot.send_message(
+                user_id,
+                "Ваши настройки:",
+                reply_markup=build_settings_keyboard(),
+            )
         # Выбор резюме
         elif data.startswith("select_resume_"):
             resume_id = data.split("_")[-1]
@@ -140,46 +226,103 @@ async def telegram_webhook(request: Request, token: str):
         if pending:
             if pending == "region":
                 suggestions = await hh_api.get_area_suggestions(text)
-                # сразу сохраняем, если ввод содержится в названии
-                match = next((a for a in suggestions if text.lower() in a.name.lower()), None)
+                match = next((a for a in suggestions if text.lower() == a.name.lower()), None)
                 if match:
                     await save_user_setting(user_id, "region", match.id)
                     await set_pending(user_id, None)
-                    await bot.send_message(user_id, f"Регион «{match.name}» сохранён 👍")
-                else:
-                    # предлагаем кнопки для выбора
-                    kb_rows = [[
-                        types.InlineKeyboardButton(area.name, callback_data=f"region_suggest_{area.id}")
-                    ] for area in suggestions[:6]]
+                    await bot.send_message(user_id, f"✅ Регион установлен: {match.name}")
                     await bot.send_message(
                         user_id,
-                        "Регион не найден. Выберите вариант из списка ниже:",
-                        reply_markup=types.InlineKeyboardMarkup(inline_keyboard=kb_rows)
+                        "Ваши настройки:",
+                        reply_markup=build_settings_keyboard(),
                     )
+                    return {"ok": True}
+                kb_rows = [
+                    [
+                        types.InlineKeyboardButton(area.name, callback_data=f"region_suggest_{area.id}")
+                    ]
+                    for area in suggestions[:6]
+                ]
+                await bot.send_message(
+                    user_id,
+                    "❓ Уточните регион, выберите из списка:",
+                    reply_markup=types.InlineKeyboardMarkup(inline_keyboard=kb_rows)
+                )
                 return {"ok": True}
 
             if pending == "schedule":
-                await save_user_setting(user_id, "schedule", text)
-                await set_pending(user_id, None)
-                await bot.send_message(user_id, "График работы сохранён 👍")
+                match = next((s for s in SCHEDULE_SUGGESTIONS if text.lower() == s.lower()), None)
+                if match:
+                    await save_user_setting(user_id, "schedule", match)
+                    await set_pending(user_id, None)
+                    await bot.send_message(user_id, f"✅ График работы установлен: {match}")
+                    await bot.send_message(user_id, "Ваши настройки:", reply_markup=build_settings_keyboard())
+                    return {"ok": True}
+                kb_rows = [
+                    [types.InlineKeyboardButton(val, callback_data=f"schedule_suggest_{val}")]
+                    for val in SCHEDULE_SUGGESTIONS[:6]
+                ]
+                await bot.send_message(
+                    user_id,
+                    "❓ Уточните график, выберите из списка:",
+                    reply_markup=types.InlineKeyboardMarkup(inline_keyboard=kb_rows)
+                )
                 return {"ok": True}
 
             if pending == "work_format":
-                await save_user_setting(user_id, "work_format", text)
-                await set_pending(user_id, None)
-                await bot.send_message(user_id, "Формат работы сохранён 👍")
+                match = next((s for s in WORK_FORMAT_SUGGESTIONS if text.lower() == s.lower()), None)
+                if match:
+                    await save_user_setting(user_id, "work_format", match)
+                    await set_pending(user_id, None)
+                    await bot.send_message(user_id, f"✅ Формат работы установлен: {match}")
+                    await bot.send_message(user_id, "Ваши настройки:", reply_markup=build_settings_keyboard())
+                    return {"ok": True}
+                kb_rows = [
+                    [types.InlineKeyboardButton(val, callback_data=f"work_format_suggest_{val}")]
+                    for val in WORK_FORMAT_SUGGESTIONS[:6]
+                ]
+                await bot.send_message(
+                    user_id,
+                    "❓ Уточните формат работы, выберите из списка:",
+                    reply_markup=types.InlineKeyboardMarkup(inline_keyboard=kb_rows)
+                )
                 return {"ok": True}
 
             if pending == "salary":
-                await save_user_setting(user_id, "salary", text)
-                await set_pending(user_id, None)
-                await bot.send_message(user_id, "Зарплата сохранена 👍")
+                if text.isdigit():
+                    await save_user_setting(user_id, "salary", text)
+                    await set_pending(user_id, None)
+                    await bot.send_message(user_id, "✅ Зарплата установлена")
+                    await bot.send_message(user_id, "Ваши настройки:", reply_markup=build_settings_keyboard())
+                    return {"ok": True}
+                kb_rows = [
+                    [types.InlineKeyboardButton(val, callback_data=f"salary_suggest_{val}")]
+                    for val in SALARY_SUGGESTIONS[:6]
+                ]
+                await bot.send_message(
+                    user_id,
+                    "❓ Введите число или выберите из вариантов:",
+                    reply_markup=types.InlineKeyboardMarkup(inline_keyboard=kb_rows)
+                )
                 return {"ok": True}
 
             if pending == "employment_type":
-                await save_user_setting(user_id, "employment_type", text)
-                await set_pending(user_id, None)
-                await bot.send_message(user_id, "Тип занятости сохранён 👍")
+                match = next((s for s in EMPLOYMENT_TYPE_SUGGESTIONS if text.lower() == s.lower()), None)
+                if match:
+                    await save_user_setting(user_id, "employment_type", match)
+                    await set_pending(user_id, None)
+                    await bot.send_message(user_id, f"✅ Тип занятости установлен: {match}")
+                    await bot.send_message(user_id, "Ваши настройки:", reply_markup=build_settings_keyboard())
+                    return {"ok": True}
+                kb_rows = [
+                    [types.InlineKeyboardButton(val, callback_data=f"employment_type_suggest_{val}")]
+                    for val in EMPLOYMENT_TYPE_SUGGESTIONS[:6]
+                ]
+                await bot.send_message(
+                    user_id,
+                    "❓ Уточните тип занятости, выберите из списка:",
+                    reply_markup=types.InlineKeyboardMarkup(inline_keyboard=kb_rows)
+                )
                 return {"ok": True}
 
             if pending == "keyword":


### PR DESCRIPTION
## Summary
- add predefined lists for filter suggestions
- handle callbacks for region and other filters with confirmation messages
- update pending message logic to show choices and validate input

## Testing
- `python -m py_compile tg_register.py settings_utils.py resume_utils.py hh_api.py main.py tg_bridge.py chatgpt_client.py migrate_settings.py test_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651e1e79c48324912be5598809ca40