### PR TITLE
Fix settings message editing

### DIFF
--- a/migrate_settings.py
+++ b/migrate_settings.py
@@ -9,11 +9,20 @@ async def upgrade(db: aiosqlite.Connection):
     Создаёт таблицы users, user_tokens, queues и user_settings, если они не существуют.
     """
     # Таблица пользователей Telegram
-    await db.execute("""
+    await db.execute(
+        """
         CREATE TABLE IF NOT EXISTS users (
-            chat_id INTEGER PRIMARY KEY
+            chat_id INTEGER PRIMARY KEY,
+            settings_msg_id INTEGER
         );
-    """)
+    """
+    )
+
+    # Добавляем колонку settings_msg_id, если база старая
+    async with db.execute("PRAGMA table_info(users)") as cur:
+        cols = [row[1] async for row in cur]
+    if "settings_msg_id" not in cols:
+        await db.execute("ALTER TABLE users ADD COLUMN settings_msg_id INTEGER")
 
     # Таблица токенов пользователей
     await db.execute("""


### PR DESCRIPTION
## Summary
- track `/settings` message id in database
- safely edit settings text by stored id
- alter `users` table with `settings_msg_id`
- handle filter callbacks without creating duplicate messages
- support pending region/salary input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686674ff8bec8324aa1a441092f58231