### PR TITLE
Add filter summary view and keyword input

### DIFF
--- a/hh_api.py
+++ b/hh_api.py
@@ -136,3 +136,15 @@ async def get_area_suggestions(query: str) -> List[AreaSuggestion]:
     items = data.get("items", [])
     # из каждого элемента берём 'text' (имя) и 'id'
     return [AreaSuggestion(item["text"], item["id"]) for item in items]
+
+
+async def area_name(area_id: str | int) -> str:
+    """Возвращает название региона по его id."""
+    url = f"https://api.hh.ru/areas/{area_id}"
+    async with httpx.AsyncClient() as client:
+        try:
+            resp = await client.get(url, timeout=5.0)
+            resp.raise_for_status()
+            return resp.json().get("name", str(area_id))
+        except Exception:
+            return str(area_id)

--- a/settings_utils.py
+++ b/settings_utils.py
@@ -75,5 +75,8 @@ def build_settings_keyboard() -> InlineKeyboardMarkup:
             InlineKeyboardButton(text="Тип занятости", callback_data="filter_employment_type"),
             InlineKeyboardButton(text="Ключевое слово", callback_data="filter_keyword"),
         ],
+        [
+            InlineKeyboardButton(text="\U0001F441\uFE0F Просмотр", callback_data="show_filters"),
+        ],
     ]
     return InlineKeyboardMarkup(inline_keyboard=keyboard)


### PR DESCRIPTION
## Summary
- include a "👁️ Просмотр" option in settings keyboard
- implement helper to build filter summary
- handle `show_filters` callback
- support keyword filter entry and saving
- expose `area_name` helper in hh_api

## Testing
- `python -m py_compile hh_api.py settings_utils.py tg_register.py resume_utils.py main.py tg_bridge.py migrate_settings.py chatgpt_client.py test_app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68667bcf9ae88324bc427af31da2db2d