### PR TITLE
Improve filter summary view

### DIFF
--- a/hh_api.py
+++ b/hh_api.py
@@ -138,13 +138,16 @@ async def get_area_suggestions(query: str) -> List[AreaSuggestion]:
     return [AreaSuggestion(item["text"], item["id"]) for item in items]
 
 
-async def area_name(area_id: str | int) -> str:
-    """Возвращает название региона по его id."""
+async def area_name(area_id: int | str | None) -> str:
+    """Возвращает название региона по его id с graceful fallback."""
+    if not area_id:
+        return "—"
     url = f"https://api.hh.ru/areas/{area_id}"
     async with httpx.AsyncClient() as client:
         try:
             resp = await client.get(url, timeout=5.0)
             resp.raise_for_status()
-            return resp.json().get("name", str(area_id))
+            data = resp.json()
+            return data.get("name") or str(area_id)
         except Exception:
             return str(area_id)

--- a/tg_register.py
+++ b/tg_register.py
@@ -3,7 +3,6 @@ import logging
 from dotenv import load_dotenv
 
 import aiosqlite
-import time
 from fastapi import FastAPI, Request, HTTPException
 from aiogram import Bot, types
 from aiogram.exceptions import TelegramBadRequest
@@ -144,8 +143,12 @@ async def safe_edit_markup(message: types.Message, markup: types.InlineKeyboardM
             raise
 
 
-async def safe_edit_text(message: types.Message, text: str,
-                         markup: types.InlineKeyboardMarkup | None):
+async def safe_edit_text(
+    message: types.Message,
+    text: str,
+    markup: types.InlineKeyboardMarkup | None,
+    md: bool = False,
+):
     """Безопасно обновить текст сообщения и клавиатуру."""
     try:
         await bot.edit_message_text(
@@ -153,6 +156,7 @@ async def safe_edit_text(message: types.Message, text: str,
             chat_id=message.chat.id,
             message_id=message.message_id,
             reply_markup=markup,
+            parse_mode="MarkdownV2" if md else None,
         )
     except TelegramBadRequest as e:
         if "message is not modified" not in str(e):
@@ -204,6 +208,7 @@ async def safe_edit_text_by_id(
     msg_id: int | None,
     text: str,
     markup: types.InlineKeyboardMarkup | None,
+    md: bool = False,
 ):
     """Редактирует сообщение по id, отправляя новое при ошибке."""
     if msg_id is None:
@@ -216,6 +221,7 @@ async def safe_edit_text_by_id(
             chat_id=uid,
             message_id=msg_id,
             reply_markup=markup,
+            parse_mode="MarkdownV2" if md else None,
         )
     except TelegramBadRequest as e:
         err = str(e).lower()
@@ -292,6 +298,7 @@ async def telegram_webhook(request: Request, token: str):
                         [types.InlineKeyboardButton("⬅️ Назад", callback_data="back_settings")]
                     ]
                 ),
+                md=True,
             )
             await bot.answer_callback_query(call.id)
             return {"ok": True}


### PR DESCRIPTION
## Summary
- add markdown support to helper text editing
- fallback handling for unknown area IDs
- include markdown parse mode when showing filter summary
- drop unused import

## Testing
- `python -m py_compile hh_api.py settings_utils.py tg_register.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667e8cbcfc832494314fd14a47c384