### PR TITLE
Add new main menu navigation

### DIFF
--- a/resume_utils.py
+++ b/resume_utils.py
@@ -1,10 +1,38 @@
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+import os
+import aiosqlite
+from hh_api import HHClient
 
-def build_resume_keyboard(resume_list: list) -> InlineKeyboardMarkup:
-    """
-    resume_list — список кортежей (resume_id, resume_name)
-    """
+DB_PATH = "tg_users.db"
+
+async def _get_user_token(tg_user: int) -> str | None:
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT access_token FROM user_tokens WHERE tg_user = ?",
+            (tg_user,),
+        ) as cur:
+            row = await cur.fetchone()
+            return row[0] if row else None
+
+async def build_resume_keyboard(uid: int) -> InlineKeyboardMarkup:
+    """Запрашивает список резюме пользователя и строит клавиатуру."""
+    token = await _get_user_token(uid)
+    if not token:
+        return InlineKeyboardMarkup(inline_keyboard=[])
+
+    client = HHClient(
+        os.getenv("HH_CLIENT_ID"),
+        os.getenv("HH_CLIENT_SECRET"),
+        os.getenv("REDIRECT_URI"),
+    )
+    try:
+        resumes = await client.list_resumes(token)
+    finally:
+        await client.close()
+
     kb = InlineKeyboardMarkup(row_width=1)
-    for r_id, r_name in resume_list:
-        kb.add(InlineKeyboardButton(r_name, callback_data=f"select_resume_{r_id}"))
+    for item in resumes:
+        rid = item.get("id")
+        title = item.get("title") or item.get("profession") or "Без названия"
+        kb.add(InlineKeyboardButton(title, callback_data=f"select_resume_{rid}"))
     return kb

--- a/settings_utils.py
+++ b/settings_utils.py
@@ -56,13 +56,19 @@ async def get_user_setting(tg_user: int, key: str) -> Optional[str]:
             return row[0] if row else None
 
 
-def build_settings_keyboard() -> InlineKeyboardMarkup:
-    """
-    Строит клавиатуру фильтров для настроек. Кнопки в два ряда:
-    Регион, График, Формат работы, ЗП, Тип занятости, Ключевое слово
-    """
-    # Группируем кнопки по по два в ряд
-    keyboard = [
+def build_main_menu_keyboard() -> InlineKeyboardMarkup:
+    """Главное меню бота."""
+    kb = [
+        [InlineKeyboardButton("⚙️ Настройка фильтров", callback_data="open_settings")],
+        [InlineKeyboardButton("📄 Резюме", callback_data="open_resumes")],
+        [InlineKeyboardButton("👁️ Просмотр фильтров", callback_data="show_filters")],
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=kb)
+
+
+def build_settings_keyboard(with_back: bool = True) -> InlineKeyboardMarkup:
+    """Клавиатура управления фильтрами."""
+    rows = [
         [
             InlineKeyboardButton(text="Регион", callback_data="filter_region"),
             InlineKeyboardButton(text="График", callback_data="filter_schedule"),
@@ -75,8 +81,7 @@ def build_settings_keyboard() -> InlineKeyboardMarkup:
             InlineKeyboardButton(text="Тип занятости", callback_data="filter_employment_type"),
             InlineKeyboardButton(text="Ключевое слово", callback_data="filter_keyword"),
         ],
-        [
-            InlineKeyboardButton(text="\U0001F441\uFE0F Просмотр", callback_data="show_filters"),
-        ],
     ]
-    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+    if with_back:
+        rows.append([InlineKeyboardButton("⬅️ В меню", callback_data="back_menu")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)


### PR DESCRIPTION
## Summary
- add main menu keyboard and update settings keyboard
- fetch resumes asynchronously when showing resume keyboard
- implement `/menu` command and related callbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686684f2ec788324bd5ffd36eb83a4bb