### PR TITLE
Fix HH API headers and resume keyboard

### DIFF
--- a/hh_api.py
+++ b/hh_api.py
@@ -3,34 +3,35 @@ import httpx
 from typing import Any, Dict, List
 
 
-class HHClient:
+class HHApiClient:
     # Константы API
     BASE_URL = "https://api.hh.ru"
     AUTH_URL = "https://hh.ru/oauth/authorize"  # всегда hh.ru
     TOKEN_URL = "https://hh.ru/oauth/token"
 
-    def __init__(self, client_id: str, client_secret: str, redirect_uri: str):
-        """
-        Инициализация клиента.
-        """
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.redirect_uri = redirect_uri
-        ua = os.getenv("HH_UA", "AutoReplyBot/1.0 (contact@example.com)")
-        self.client = httpx.AsyncClient(timeout=10, headers={"User-Agent": ua})
+    def __init__(self, token: str | None = None):
+        """Базовая инициализация клиента HH API."""
+        self._headers = {
+            "User-Agent": os.getenv(
+                "HH_USER_AGENT", "HH HunterBot/1.0 (tg:@your_nick)"
+            )
+        }
+        if token:
+            self._headers["Authorization"] = f"Bearer {token}"
+        self._client = httpx.AsyncClient(
+            base_url="https://api.hh.ru", headers=self._headers, timeout=15
+        )
 
     async def exchange_code_for_token(self, code: str) -> Dict[str, Any]:
-        """
-        Обменивает authorization code на пару токенов.
-        """
+        """Обменивает authorization code на пару токенов."""
         data = {
             "grant_type": "authorization_code",
-            "client_id": self.client_id,
-            "client_secret": self.client_secret,
+            "client_id": os.getenv("HH_CLIENT_ID"),
+            "client_secret": os.getenv("HH_CLIENT_SECRET"),
             "code": code,
-            "redirect_uri": self.redirect_uri,
+            "redirect_uri": os.getenv("REDIRECT_URI"),
         }
-        resp = await self.client.post(self.TOKEN_URL, data=data)
+        resp = await self._client.post(self.TOKEN_URL, data=data)
         if resp.status_code != 200:
             # Логируем код и тело ответа
             import logging
@@ -39,59 +40,43 @@ class HHClient:
             resp.raise_for_status()
         return resp.json()
 
-    async def _auth_headers(self, access_token: str) -> Dict[str, str]:
-        return {"Authorization": f"Bearer {access_token}"}
-
     async def search_vacancies(
         self,
-        access_token: str,
         text: str,
-        per_page: int = 20
+        per_page: int = 20,
     ) -> List[Dict[str, Any]]:
         """
         Поиск вакансий по тексту.
         """
         params = {"text": text, "per_page": per_page}
-        resp = await self.client.get(
+        resp = await self._client.get(
             f"{self.BASE_URL}/vacancies",
             params=params,
-            headers=await self._auth_headers(access_token),
         )
         resp.raise_for_status()
         return resp.json().get("items", [])
 
-    async def list_resumes(self, access_token: str) -> List[Dict[str, Any]]:
+    async def list_resumes(self) -> List[Dict[str, Any]]:
         """
         Получение списка резюме пользователя.
         """
-        resp = await self.client.get(
-            f"{self.BASE_URL}/resumes/mine",
-            headers=await self._auth_headers(access_token),
-        )
+        resp = await self._client.get(f"{self.BASE_URL}/resumes/mine")
         resp.raise_for_status()
         return resp.json().get("items", [])
 
-    async def get_vacancy(
-        self,
-        vacancy_id: str,
-        access_token: str
-    ) -> Dict[str, Any]:
+    async def get_vacancy(self, vacancy_id: str) -> Dict[str, Any]:
         """
         Получение детальной информации о вакансии по ID.
         """
-        resp = await self.client.get(
-            f"{self.BASE_URL}/vacancies/{vacancy_id}",
-            headers=await self._auth_headers(access_token),
-        )
+        resp = await self._client.get(f"{self.BASE_URL}/vacancies/{vacancy_id}")
         resp.raise_for_status()
         return resp.json()
 
     async def respond_to_vacancy(
         self,
-        access_token: str,
         vacancy_id: str,
         resume_id: str,
-        cover_letter: str
+        cover_letter: str,
     ) -> Dict[str, Any]:
         """
         Отправка отклика на вакансию (создание переговоров).
@@ -101,10 +86,9 @@ class HHClient:
             "resume_id": resume_id,
             "cover_letter": cover_letter,
         }
-        resp = await self.client.post(
+        resp = await self._client.post(
             f"{self.BASE_URL}/negotiations",
             json=payload,
-            headers=await self._auth_headers(access_token),
         )
         resp.raise_for_status()
         return resp.json()
@@ -113,7 +97,7 @@ class HHClient:
         """
         Закрывает HTTP-сессию.
         """
-        await self.client.aclose()
+        await self._client.aclose()
 
 
 class AreaSuggestion:
@@ -139,7 +123,10 @@ async def get_area_suggestions(query: str) -> List[AreaSuggestion]:
 
 
 # общий клиент HH API для простых запросов
-client = httpx.AsyncClient(base_url="https://api.hh.ru", timeout=5.0)
+_ua = os.getenv("HH_USER_AGENT", "HH HunterBot/1.0 (tg:@your_nick)")
+client = httpx.AsyncClient(
+    base_url="https://api.hh.ru", timeout=5.0, headers={"User-Agent": _ua}
+)
 
 
 async def area_name(area_id: str | int | None) -> str:

--- a/tg_register.py
+++ b/tg_register.py
@@ -294,11 +294,6 @@ async def telegram_webhook(request: Request, token: str):
         # === открыть резюме ===
         if data == "open_resumes":
             kb = await build_resume_keyboard(uid)
-            kb.add(
-                types.InlineKeyboardButton(
-                    text="⬅️ В меню", callback_data="back_menu"
-                )
-            )
             await safe_edit_text(
                 call.message,
                 "📄 Ваши резюме:",


### PR DESCRIPTION
## Summary
- include User-Agent header in HH API client and global helper
- handle missing or expired tokens when listing resumes
- create authorization URL helper in `resume_utils`
- attach back button in the resume keyboard
- update Telegram handlers and HTTP endpoints to new API client usage

## Testing
- `python -m py_compile hh_api.py main.py resume_utils.py tg_register.py settings_utils.py chatgpt_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b3da852083249c7a31f84c56f317